### PR TITLE
Add emergency favicon and correct hotline numbers

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#dc2626"/>
+  <rect x="196" y="64" width="120" height="384" fill="#ffffff"/>
+  <rect x="64" y="196" width="384" height="120" fill="#ffffff"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Emergencias - JAVERIM & Hatzala</title>
-    <link rel="manifest" href="data:application/json;base64,eyJuYW1lIjoiRW1lcmdlbmNpYXMgLSBKQVZFUklNICYgSGF0emFsYSIsInNob3J0X25hbWUiOiJFbWVyZ2VuY2lhcyIsInN0YXJ0X3VybCI6Ii8iLCJkaXNwbGF5Ijoic3RhbmRhbG9uZSIsImJhY2tncm91bmRfY29sb3IiOiIjMTExODI3IiwidGhlbWVfY29sb3IiOiIjZGMyNjI2IiwiaWNvbnMiOlt7InNyYyI6ImRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjNhV1IwYUQwaU1UazJJaUJvWldsbmFIUTlJakU1TmlJZ2RtbGxkMEp2ZUQwaU1DQXdJREU1TmlBeE9UWWlJR1pwYkd3OUlpTmtZekkyTWpZaVBnbzhZMmx5WTJ4bElHTjRQU0k1T0NJZ1kzazlJams0SWlCeVBTSTBPQ0k5UEM5amFYSmpiR1UrUEM5emRtYysiLCJzaXplcyI6IjE5MngxOTIiLCJ0eXBlIjoiaW1hZ2Uvc3ZnK3htbCJ9XX0=">
+    <link rel="manifest" href="manifest.webmanifest">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <meta name="theme-color" content="#dc2626">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -224,12 +225,12 @@
         </div>
 
         <div class="emergency-buttons">
-            <a href="tel:+5491234567890" class="emergency-btn javerim-btn">
+            <a href="tel:+5491150326851" class="emergency-btn javerim-btn">
                 <span class="icon">📞</span>
                 <span>JAVERIM</span>
             </a>
 
-            <a href="tel:+5491234567891" class="emergency-btn hatzala-btn">
+            <a href="tel:50322626" class="emergency-btn hatzala-btn">
                 <span class="icon">🚑</span>
                 <span>HATZALA</span>
             </a>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Emergencias - JAVERIM & Hatzala",
+  "short_name": "Emergencias",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111827",
+  "theme_color": "#dc2626",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add emergency cross favicon and reference it via manifest
- correct Javerim and Hatzala hotline numbers

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f3a013ec832ca6cff5cb9b4ac055